### PR TITLE
fix cutkey call type checking for tuple input

### DIFF
--- a/c_src/cutkey.c
+++ b/c_src/cutkey.c
@@ -138,7 +138,7 @@ static ErlDrvSSizeT call(ErlDrvData edd, unsigned int cmd, char *buf,
   if (cmd == CUTKEY_CMD_RSA) {
     errno = CUTKEY_ERR_ARG;
     ei_decode_ei_term(buf, &index, &tuple);
-    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
+    if (tuple.ei_type != ERL_SMALL_TUPLE_EXT || tuple.arity != 3) {
       goto error;
     }
     ei_decode_ei_term(buf, &index, &ref);


### PR DESCRIPTION
cutkey_drv passes the two-tuple `{Ref, Bits, E}` via `erlang:port_call/3`, and the c code guards against invalid input by verifying that the input is a tuple of arity 3. However, it uses the constant `ERL_TUPLE` from erl_interface.h to check that the `ei_type` is a tuple. It appears that this is incorrect usage, and it should *actually* be compared against `ERL_SMALL_TUPLE_EXT` from `erl_interface/include/ei.h`.

Previously, a large warning was generated:

```
Compiling c_src/cutkey.c
c_src/cutkey.c:141:9: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
        ^              ~~
c_src/cutkey.c:141:9: note: add parentheses after the '!' to evaluate the comparison first
    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
        ^
         (                         )
c_src/cutkey.c:141:9: note: add parentheses around left hand side expression to silence this warning
    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
        ^
        (             )
c_src/cutkey.c:141:24: warning: comparison of constant 137 with boolean expression is always false [-Wtautological-constant-out-of-range-compare]
    if (!tuple.ei_type == ERL_TUPLE || tuple.arity != 3) {
        ~~~~~~~~~~~~~~ ^  ~~~~~~~~~
2 warnings generated.
```

It appears that the left hand side of this boolean evaluation is always false, and since the `tuple.arity != 3` is also false on valid inputs, an error isn’t triggered.

This change modifies the `ei_type` check to verify that the value is the correct thing that it should be, and squelches the warning  generated by the ambiguous placement of `!`.