### PR TITLE
add pc plugin here for less overrides in top level apps. 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,3 +9,13 @@
   {"LDFLAGS", "$LDFLAGS -lcrypto"}
 ]}.
 {erl_opts, [warnings_as_errors]}.
+
+{plugins, [pc]}.
+{provider_hooks,
+  [
+    {pre,
+      [
+        {compile, {pc, compile}},
+        {clean, {pc, clean}}
+      ]}
+  ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,7 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> CONFIG;
+    false -> 
+        %% remove pc plugin for rebar2 builds... cause doh!
+        {plugins, Plugins} = lists:keyfind(plugins, 1, CONFIG),
+        lists:keystore(plugins, 1, CONFIG, {plugins, lists:delete(pc, Plugins)})
+end.


### PR DESCRIPTION
@fp what do you think?

it's seems it's okay for old `rebar` too as it just has a warning about missing plugin but still compiles/tests stuff. 

I might craft smth to make it only if `rebar3` is used but before doing such massive compile changes I would like to agree on direction. 